### PR TITLE
Unify access to properties of objects and singular instances of them

### DIFF
--- a/ertapi/ensemble/parameter.py
+++ b/ertapi/ensemble/parameter.py
@@ -16,3 +16,7 @@ class Parameter(RequestData):
     @property
     def group(self):
         return self.metadata["group"]
+
+    @property
+    def key(self):
+        return self.metadata["key"]

--- a/ertapi/ensemble/realization.py
+++ b/ertapi/ensemble/realization.py
@@ -1,4 +1,4 @@
-from ertapi.ensemble.request_data import RequestData
+from ertapi.ensemble.request_data import RequestData, ParametersDict
 
 
 class Realization(RequestData):
@@ -26,4 +26,4 @@ class Realization(RequestData):
 
     @property
     def parameters(self):
-        return self.get_node_fields("parameters", key=["name"])
+        return ParametersDict("parameters", "name", self)

--- a/tests/ertapi/test_ensembles.py
+++ b/tests/ertapi/test_ensembles.py
@@ -40,7 +40,7 @@ def test_parameter_api(mock_requests_handler):
 
     param = Ensembles(request_handler=mock_requests_handler, metadata_dict=url)[
         0
-    ].parameter("BPR_138_PERSISTENCE")
+    ].parameters["BPR_138_PERSISTENCE"]
     assert (
         param.metadata["alldata_url"]
         == "http://127.0.0.1:5000/ensembles/1/parameters/1/data"
@@ -61,7 +61,7 @@ def test_realization_api(mock_requests_handler):
 
     assert ens_default.realizations.name == [0, 1, 2]
 
-    real_0 = ens_default.realization(0)
+    real_0 = ens_default.realizations[0]
     assert real_0.parameters.name == [
         "BPR_138_PERSISTENCE",
         "BPR_555_PERSISTENCE",


### PR DESCRIPTION
This PR should unify access to objects. For instance,
`ensemble.parameters.key` will provide a list of all parameters key within ensemble while
`ensemble.parameters['PARAM_KEY'`]` will just get a single instance of this parameter. The same holds for other objects too.